### PR TITLE
Update 'deface' dependency version

### DIFF
--- a/solidus_static_content.gemspec
+++ b/solidus_static_content.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3']
   s.add_dependency "solidus_support"
-  s.add_dependency 'deface', '~> 1.0'
+  s.add_dependency 'deface', '>= 1.3.1'
 
   s.add_development_dependency 'capybara', '~> 2.7'
   s.add_development_dependency 'factory_bot', '~> 4.7'


### PR DESCRIPTION
Ref: https://github.com/sparklemotion/nokogiri/issues/1785

Updated 'deface' gem to update 'nokogiri' dependency gem after the vulnerability 
checks with 'audit':
Nokogiri gem, via libxml2, is affected by multiple vulnerabilities.